### PR TITLE
Add meta tags for social sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,22 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Smpl Timer</title>
+    
+    <!-- Primary Meta Tags -->
+    <meta name="title" content="Smpl Timer">
+    <meta name="description" content="A minimal stopwatch that displays the current lap time as the primary timer, with total elapsed time shown below. Perfect for timing reading sessions where individual segments matter more than total time.">
+    
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://kylechadha.github.io/smpl-timer/">
+    <meta property="og:title" content="Smpl Timer">
+    <meta property="og:description" content="A minimal stopwatch that displays the current lap time as the primary timer, with total elapsed time shown below. Perfect for timing reading sessions where individual segments matter more than total time.">
+    
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary">
+    <meta property="twitter:url" content="https://kylechadha.github.io/smpl-timer/">
+    <meta property="twitter:title" content="Smpl Timer">
+    <meta property="twitter:description" content="A minimal stopwatch that displays the current lap time as the primary timer, with total elapsed time shown below. Perfect for timing reading sessions where individual segments matter more than total time.">
     <style>
         :root {
             --font-stack: -apple-system, BlinkMacSystemFont, 'SF Pro Display', system-ui, sans-serif;


### PR DESCRIPTION
Add Open Graph and Twitter Card meta tags so link previews show proper title and description when shared on WhatsApp, Twitter, etc.